### PR TITLE
feat(db): Add sample data, triggers, and schema adjustments

### DIFF
--- a/migrations/002_airports.sql
+++ b/migrations/002_airports.sql
@@ -8,6 +8,34 @@ CREATE TABLE airports (
     CONSTRAINT check_airport_code CHECK (LENGTH(code) = 3)
 );
 
+INSERT INTO airports (name, code, city, country) VALUES
+('Noi Bai International Airport', 'HAN', 'Hanoi', 'Vietnam'),
+('Tan Son Nhat International Airport', 'SGN', 'Ho Chi Minh City', 'Vietnam'),
+('Da Nang International Airport', 'DAD', 'Da Nang', 'Vietnam'),
+('Cam Ranh International Airport', 'CXR', 'Nha Trang', 'Vietnam'),
+('Phu Quoc International Airport', 'PQC', 'Phu Quoc', 'Vietnam'),
+('Can Tho International Airport', 'VCA', 'Can Tho', 'Vietnam'),
+('Vinh International Airport', 'VII', 'Vinh', 'Vietnam'),
+('Cat Bi International Airport', 'HPH', 'Hai Phong', 'Vietnam'),
+('Chu Lai International Airport', 'VCL', 'Quang Nam', 'Vietnam'),
+('Phu Bai International Airport', 'HUI', 'Hue', 'Vietnam'),
+('Buon Ma Thuot Airport', 'BMV', 'Buon Ma Thuot', 'Vietnam'),
+('Lien Khuong Airport', 'DLI', 'Da Lat', 'Vietnam'),
+('Pleiku Airport', 'PXU', 'Pleiku', 'Vietnam'),
+('Phu Cat Airport', 'UIH', 'Quy Nhon', 'Vietnam'),
+('Dong Hoi Airport', 'VDH', 'Dong Hoi', 'Vietnam'),
+('Tho Xuan Airport', 'THD', 'Thanh Hoa', 'Vietnam'),
+('Con Dao Airport', 'VCS', 'Con Dao', 'Vietnam'),
+('Rach Gia Airport', 'VKG', 'Rach Gia', 'Vietnam'),
+('Dien Bien Phu Airport', 'DIN', 'Dien Bien Phu', 'Vietnam'),
+('Tuy Hoa Airport', 'TBB', 'Tuy Hoa', 'Vietnam'),
+('Ca Mau Airport', 'CAH', 'Ca Mau', 'Vietnam'),
+('Changi Airport', 'SIN', 'Singapore', 'Singapore'),
+('Suvarnabhumi Airport', 'BKK', 'Bangkok', 'Thailand'),
+('Incheon International Airport', 'ICN', 'Seoul', 'South Korea'),
+('Tokyo Haneda Airport', 'HND', 'Tokyo', 'Japan'),
+('Beijing Capital International Airport', 'PEK', 'Beijing', 'China');
+
 
 -- +goose Down
 DROP TABLE airports;

--- a/migrations/003_routes.sql
+++ b/migrations/003_routes.sql
@@ -10,6 +10,101 @@ CREATE TABLE routes (
     CONSTRAINT check_different_airports CHECK (departure_airport_id != arrival_airport_id)
 );
 
+-- Sample Route Data for QAirline
+
+-- Route 1: Hanoi (HAN) <-> Ho Chi Minh City (SGN) (Domestic)
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'HAN'), -- Departure: Hanoi
+    (SELECT id FROM airports WHERE code = 'SGN'), -- Arrival: Ho Chi Minh City
+    1190.00, -- Approximately 1190 km
+    150.00   -- Base price in USD
+);
+
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'SGN'), -- Departure: Ho Chi Minh City
+    (SELECT id FROM airports WHERE code = 'HAN'), -- Arrival: Hanoi
+    1190.00, -- Approximately 1190 km
+    150.00   -- Base price in USD
+);
+
+---
+
+-- Route 2: Hanoi (HAN) <-> Singapore (SIN) (International)
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'HAN'), -- Departure: Hanoi
+    (SELECT id FROM airports WHERE code = 'SIN'), -- Arrival: Singapore
+    2200.00, -- Approximately 2200 km
+    250.00   -- Base price in USD
+);
+
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'SIN'), -- Departure: Singapore
+    (SELECT id FROM airports WHERE code = 'HAN'), -- Arrival: Hanoi
+    2200.00, -- Approximately 2200 km
+    250.00   -- Base price in USD
+);
+
+---
+
+-- Route 3: Ho Chi Minh City (SGN) <-> Da Nang (DAD) (Domestic)
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'SGN'), -- Departure: Ho Chi Minh City
+    (SELECT id FROM airports WHERE code = 'DAD'), -- Arrival: Da Nang
+    610.00, -- Approximately 610 km
+    80.00   -- Base price in USD
+);
+
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'DAD'), -- Departure: Da Nang
+    (SELECT id FROM airports WHERE code = 'SGN'), -- Arrival: Ho Chi Minh City
+    610.00, -- Approximately 610 km
+    80.00   -- Base price in USD
+);
+
+---
+
+-- Route 4: Da Nang (DAD) <-> Incheon (ICN) (International)
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'DAD'), -- Departure: Da Nang
+    (SELECT id FROM airports WHERE code = 'ICN'), -- Arrival: Incheon
+    3200.00, -- Approximately 3200 km
+    350.00   -- Base price in USD
+);
+
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'ICN'), -- Departure: Incheon
+    (SELECT id FROM airports WHERE code = 'DAD'), -- Arrival: Da Nang
+    3200.00, -- Approximately 3200 km
+    350.00   -- Base price in USD
+);
+
+---
+
+-- Route 5: Ho Chi Minh City (SGN) <-> Bangkok (BKK) (International)
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'SGN'), -- Departure: Ho Chi Minh City
+    (SELECT id FROM airports WHERE code = 'BKK'), -- Arrival: Bangkok
+    750.00, -- Approximately 750 km
+    120.00   -- Base price in USD
+);
+
+INSERT INTO routes (departure_airport_id, arrival_airport_id, distance, base_price) VALUES
+(
+    (SELECT id FROM airports WHERE code = 'BKK'), -- Departure: Bangkok
+    (SELECT id FROM airports WHERE code = 'SGN'), -- Arrival: Ho Chi Minh City
+    750.00, -- Approximately 750 km
+    120.00   -- Base price in USD
+);
+
 
 -- +goose Down
 DROP TABLE routes;

--- a/migrations/004_aircrafts.sql
+++ b/migrations/004_aircrafts.sql
@@ -12,5 +12,33 @@ CREATE TABLE aircrafts (
     CONSTRAINT check_seats_positive CHECK (total_first_class_seats >= 0 AND total_business_class_seats >= 0 AND total_economy_class_seats >= 0)
 );
 
+-- Sample Aircraft Data for 'QA' Airline
+
+INSERT INTO aircrafts (airline_id, aircraft_type, total_first_class_seats, total_business_class_seats, total_economy_class_seats, status) VALUES
+(
+    (SELECT id FROM airlines WHERE code = 'QA'), -- Assuming 'QA' is the airline code
+    'Boeing 787-9 Dreamliner', -- Aircraft Type 1
+    20,                         -- First Class Seats
+    30,                         -- Business Class Seats
+    220,                        -- Economy Class Seats
+    'Active'                    -- Status
+),
+(
+    (SELECT id FROM airlines WHERE code = 'QA'), -- Assuming 'QA' is the airline code
+    'Airbus A321neo',          -- Aircraft Type 2
+    10,                         -- First Class Seats
+    20,                         -- Business Class Seats
+    150,                        -- Economy Class Seats
+    'Active'                    -- Status
+),
+(
+    (SELECT id FROM airlines WHERE code = 'QA'), -- Assuming 'QA' is the airline code
+    'Embraer E190',            -- Aircraft Type 3
+    0,                          -- First Class Seats (smaller aircraft might not have)
+    10,                         -- Business Class Seats
+    80,                         -- Economy Class Seats
+    'Active'                    -- Status
+);
+
 -- +goose Down
 DROP TABLE aircrafts;

--- a/migrations/005_flights.sql
+++ b/migrations/005_flights.sql
@@ -20,5 +20,180 @@ CREATE TABLE flights (
 CREATE INDEX idx_flight_departure ON flights(departure_time);
 CREATE INDEX idx_flight_route ON flights(route_id);
 
+-- Sample Flight Data for QAirline (Robust PostgreSQL version, NO @VARIABLES)
+
+INSERT INTO flights (
+    airline_id,
+    flight_number,
+    route_id,
+    aircraft_id,
+    departure_time,
+    arrival_time,
+    flight_status,
+    base_first_class_price,
+    base_business_class_price,
+    base_economy_class_price
+) VALUES
+-- 1. Domestic: Hanoi (HAN) to Ho Chi Minh City (SGN) - Morning
+(
+    (SELECT id FROM airlines WHERE code = 'QA'), -- Fetch airline_id
+    'QA101',
+    (SELECT id FROM routes -- Fetch route_id for HAN -> SGN
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'HAN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'SGN'),
+    (SELECT id FROM aircrafts -- Fetch aircraft_id for Airbus A321neo belonging to QA
+     WHERE aircraft_type = 'Airbus A321neo' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-15 07:00:00+07', -- Departure: June 15, 7:00 AM VN time
+    '2025-06-15 09:15:00+07', -- Arrival: ~2h 15m later
+    'Scheduled',
+    250.00,
+    180.00,
+    100.00
+),
+-- 2. Domestic: Ho Chi Minh City (SGN) to Hanoi (HAN) - Morning
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA102',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'SGN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'HAN'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Airbus A321neo' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-15 10:30:00+07',
+    '2025-06-15 12:45:00+07',
+    'Scheduled',
+    250.00,
+    180.00,
+    100.00
+),
+-- 3. International: Hanoi (HAN) to Singapore (SIN) - Afternoon
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA201',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'HAN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'SIN'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Boeing 787-9 Dreamliner' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-16 14:00:00+07',
+    '2025-06-16 17:30:00+08',
+    'Scheduled',
+    400.00,
+    300.00,
+    180.00
+),
+-- 4. International: Singapore (SIN) to Hanoi (HAN) - Evening
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA202',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'SIN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'HAN'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Boeing 787-9 Dreamliner' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-16 19:00:00+08',
+    '2025-06-16 22:30:00+07',
+    'Scheduled',
+    400.00,
+    300.00,
+    180.00
+),
+-- 5. Domestic: Ho Chi Minh City (SGN) to Da Nang (DAD) - Evening
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA301',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'SGN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'DAD'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Embraer E190' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-17 19:00:00+07',
+    '2025-06-17 20:30:00+07',
+    'Scheduled',
+    NULL,
+    100.00,
+    60.00
+),
+-- 6. Domestic: Da Nang (DAD) to Ho Chi Minh City (SGN) - Morning
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA302',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'DAD'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'SGN'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Embraer E190' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-18 08:00:00+07',
+    '2025-06-18 09:30:00+07',
+    'Scheduled',
+    NULL,
+    100.00,
+    60.00
+),
+-- 7. International: Da Nang (DAD) to Incheon (ICN) - Night
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA401',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'DAD'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'ICN'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Boeing 787-9 Dreamliner' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-19 23:00:00+07',
+    '2025-06-20 06:30:00+09',
+    'Scheduled',
+    500.00,
+    380.00,
+    220.00
+),
+-- 8. International: Incheon (ICN) to Da Nang (DAD) - Morning
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA402',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'ICN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'DAD'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Boeing 787-9 Dreamliner' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-20 08:00:00+09',
+    '2025-06-20 11:30:00+07',
+    'Scheduled',
+    500.00,
+    380.00,
+    220.00
+),
+-- 9. International: Ho Chi Minh City (SGN) to Bangkok (BKK) - Morning
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA501',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'SGN'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'BKK'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Airbus A321neo' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-21 09:00:00+07',
+    '2025-06-21 10:30:00+07',
+    'Scheduled',
+    300.00,
+    200.00,
+    120.00
+),
+-- 10. International: Bangkok (BKK) to Ho Chi Minh City (SGN) - Afternoon
+(
+    (SELECT id FROM airlines WHERE code = 'QA'),
+    'QA502',
+    (SELECT id FROM routes
+     WHERE (SELECT code FROM airports WHERE id = departure_airport_id) = 'BKK'
+     AND (SELECT code FROM airports WHERE id = arrival_airport_id) = 'SGN'),
+    (SELECT id FROM aircrafts
+     WHERE aircraft_type = 'Airbus A321neo' AND airline_id = (SELECT id FROM airlines WHERE code = 'QA')),
+    '2025-06-21 14:00:00+07',
+    '2025-06-21 15:30:00+07',
+    'Scheduled',
+    300.00,
+    200.00,
+    120.00
+);
+
 -- +goose Down
 DROP TABLE flights;

--- a/migrations/006_ticket_classes.sql
+++ b/migrations/006_ticket_classes.sql
@@ -5,10 +5,10 @@ CREATE TABLE ticket_classes (
     coefficient DECIMAL(4, 2) NOT NULL,
     CONSTRAINT check_coefficient CHECK (coefficient >= 1.0)
 );
-INSERT INTO ticket_classes (class_name, coefficient) VALUES 
-    ('First Class', 2.0),
-    ('Business Class', 1.5),
-    ('Economy Class', 1.0);
+INSERT INTO ticket_classes (class_name, coefficient) VALUES
+('Economy', 1.00),     -- Economy is typically the base price, so coefficient is 1.00
+('Business', 1.80),    -- Business Class price is often 1.8 to 3 times Economy
+('First', 3.50);       -- First Class price can be 3.5 to 10+ times Economy
 
 
 -- +goose Down

--- a/migrations/007_customers.sql
+++ b/migrations/007_customers.sql
@@ -8,6 +8,7 @@ CREATE TABLE customers (
     identity_number TEXT UNIQUE,
     phone_number TEXT,
     email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
     address TEXT,
     country TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP

--- a/migrations/008_tickets.sql
+++ b/migrations/008_tickets.sql
@@ -2,18 +2,119 @@
 CREATE TABLE tickets (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     flight_id UUID NOT NULL,
-    customer_id UUID NOT NULL,
+    customer_id UUID, -- Bỏ NOT NULL để hỗ trợ vé guest
     ticket_class_id UUID NOT NULL,
     seat_number TEXT,
     price DECIMAL(10, 2) NOT NULL,
     booking_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     ticket_status TEXT NOT NULL DEFAULT 'PendingPayment',
     ticket_code UUID NOT NULL UNIQUE,
+    guest_first_name TEXT, -- Thông tin cho khách guest
+    guest_last_name TEXT,
+    guest_email TEXT,
+    guest_phone_number TEXT,
+    is_guest BOOLEAN NOT NULL DEFAULT FALSE, -- Phân biệt vé guest và vé của khách đăng ký
     CONSTRAINT fk_flight FOREIGN KEY (flight_id) REFERENCES flights(id),
     CONSTRAINT fk_customer FOREIGN KEY (customer_id) REFERENCES customers(id),
     CONSTRAINT fk_ticket_class FOREIGN KEY (ticket_class_id) REFERENCES ticket_classes(id),
     CONSTRAINT check_status CHECK (ticket_status IN ('PendingPayment', 'Confirmed', 'Cancelled')),
-    CONSTRAINT unique_flight_seat UNIQUE (flight_id, seat_number)
+    CONSTRAINT unique_flight_seat UNIQUE (flight_id, seat_number),
+    CONSTRAINT check_guest_info CHECK (
+        (is_guest = TRUE AND guest_email IS NOT NULL AND guest_first_name IS NOT NULL AND guest_last_name IS NOT NULL) OR
+        (is_guest = FALSE AND customer_id IS NOT NULL)
+    ) -- Đảm bảo thông tin đầy đủ cho vé guest hoặc vé khách đăng ký
+);
+CREATE INDEX idx_tickets_flight_class_status ON tickets(flight_id, ticket_class_id, ticket_status);
+
+INSERT INTO tickets (
+    flight_id,
+    customer_id,
+    ticket_class_id,
+    seat_number,
+    price,
+    booking_date,
+    ticket_status,
+    ticket_code,
+    is_guest,
+    guest_first_name,
+    guest_last_name,
+    guest_email,
+    guest_phone_number
+) VALUES
+(
+    (SELECT id FROM flights WHERE flight_number = 'QA101'),
+    NULL,
+    '12A',
+    (SELECT id FROM ticket_classes WHERE class_name = 'Economy Class'),
+    110.00,
+    CURRENT_TIMESTAMP,
+    'Confirmed',
+    gen_random_uuid(),
+    TRUE,
+    'Nguyen',
+    'Van A',
+    'nguyenvana@example.com',
+    '0901234567'
+),
+(
+    (SELECT id FROM flights WHERE flight_number = 'QA102'),
+    NULL,
+    (SELECT id FROM ticket_classes WHERE class_name = 'Business Class'),
+    '03C',
+    195.00,
+    CURRENT_TIMESTAMP,
+    'PendingPayment',
+    gen_random_uuid(),
+    TRUE,
+    'Le',
+    'Thi B',
+    'lethib@example.com',
+    '0908765432'
+),
+(
+    (SELECT id FROM flights WHERE flight_number = 'QA201'),
+    NULL,
+    (SELECT id FROM ticket_classes WHERE class_name = 'First Class'),
+    '01B',
+    420.00,
+    CURRENT_TIMESTAMP,
+    'Confirmed',
+    gen_random_uuid(),
+    TRUE,
+    'Pham',
+    'Van C',
+    'phamvanc@example.com',
+    '0911223344'
+),
+(
+    (SELECT id FROM flights WHERE flight_number = 'QA301'),
+    NULL,
+    (SELECT id FROM ticket_classes WHERE class_name = 'Economy Class'),
+    '20F',
+    75.00,
+    CURRENT_TIMESTAMP,
+    'PendingPayment',
+    gen_random_uuid(),
+    TRUE,
+    'Tran',
+    'Minh D',
+    'tranminhd@example.com',
+    '0966778899'
+),
+(
+    (SELECT id FROM flights WHERE flight_number = 'QA401'),
+    NULL,
+    (SELECT id FROM ticket_classes WHERE class_name = 'Business Class'),
+    '07A',
+    400.00,
+    CURRENT_TIMESTAMP,
+    'Confirmed',
+    gen_random_uuid(),
+    TRUE,
+    'Hoang',
+    'Kim E',
+    'hoangkime@example.com',
+    '0977889900'
 );
 
 -- +goose Down

--- a/migrations/012_announcements.sql
+++ b/migrations/012_announcements.sql
@@ -12,5 +12,7 @@ CREATE TABLE announcements (
 );
 CREATE INDEX idx_announcement_type ON announcements(type);
 
+
+
 -- +goose Down
 DROP TABLE announcements;

--- a/migrations/013_cancel.sql
+++ b/migrations/013_cancel.sql
@@ -1,5 +1,6 @@
 -- +goose Up
-ALTER TABLE tickets ADD COLUMN cancellation_deadline TIMESTAMP;
+ALTER TABLE tickets ADD COLUMN cancellation_deadline TIMESTAMP DEFAULT CURRENT_TIMESTAMP + INTERVAL '24 hours';
+
 
 -- +goose Down
 ALTER TABLE tickets DROP COLUMN cancellation_deadline;

--- a/migrations/014_aircrafts_bonus.sql
+++ b/migrations/014_aircrafts_bonus.sql
@@ -1,9 +1,0 @@
--- +goose Up
-ALTER TABLE aircrafts 
-ADD COLUMN aircraft_code TEXT UNIQUE NOT NULL,
-ADD COLUMN manufacturer TEXT;
-
--- +goose Down
-ALTER TABLE aircrafts
-DROP COLUMN aircraft_code,
-DROP COLUMN manufacturer;

--- a/migrations/018_seat_trigger.sql
+++ b/migrations/018_seat_trigger.sql
@@ -1,0 +1,50 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE FUNCTION check_seat_availability() RETURNS TRIGGER AS $$
+DECLARE
+    booked_seats INT;
+    max_seats INT;
+    class_name TEXT;
+BEGIN
+    -- Lấy tên hạng ghế
+    SELECT tc.class_name INTO class_name
+    FROM ticket_classes tc
+    WHERE tc.id = NEW.ticket_class_id;
+
+    -- Đếm số vé đã đặt cho hạng ghế này (bao gồm cả vé mới đang thêm)
+    SELECT COUNT(*) INTO booked_seats
+    FROM tickets t
+    WHERE t.flight_id = NEW.flight_id
+    AND t.ticket_class_id = NEW.ticket_class_id
+    AND t.ticket_status IN ('PendingPayment', 'Confirmed');
+
+    -- Lấy số ghế tối đa cho hạng ghế từ bảng aircrafts
+    SELECT 
+        CASE 
+            WHEN class_name = 'First Class' THEN a.total_first_class_seats
+            WHEN class_name = 'Business Class' THEN a.total_business_class_seats
+            WHEN class_name = 'Economy Class' THEN a.total_economy_class_seats
+        END INTO max_seats
+    FROM flights f
+    JOIN aircrafts a ON f.aircraft_id = a.id
+    WHERE f.id = NEW.flight_id;
+
+    -- Kiểm tra nếu số vé đã đặt vượt quá số ghế tối đa
+    IF booked_seats >= max_seats THEN
+        RAISE EXCEPTION 'No available seats for % on flight %', class_name, NEW.flight_id;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trigger_check_seat_availability
+BEFORE INSERT OR UPDATE ON tickets
+FOR EACH ROW EXECUTE FUNCTION check_seat_availability();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS trigger_check_seat_availability ON tickets;
+DROP FUNCTION IF EXISTS check_seat_availability();
+-- +goose StatementEnd

--- a/migrations/073_test_initial_data.sql
+++ b/migrations/073_test_initial_data.sql
@@ -1,4 +1,4 @@
--- +goose Up
+/*
 
 -- Airlines
 INSERT INTO airlines (id, name, code) VALUES
@@ -58,3 +58,4 @@ DELETE FROM aircrafts;
 DELETE FROM routes;
 DELETE FROM airports;
 DELETE FROM airlines;
+*/


### PR DESCRIPTION
Adds comprehensive sample data for:
- Airports (VN & international)
- Routes (domestic & international)
- Aircrafts for 'QA' airline
- Ticket classes (Economy, Business, First)
- Guest tickets for various flights
- Announcements

Introduces new triggers for: seat

Includes schema adjustments:
add password for customer