### PR TITLE
Add new announcement validation fields

### DIFF
--- a/backend/middlewares/validateAnnouncement.js
+++ b/backend/middlewares/validateAnnouncement.js
@@ -4,9 +4,33 @@ const { handleValidationErrors } = require('../middlewares/validateUtils');
 exports.validateCreateAnnouncement = [
   body('title').notEmpty().withMessage('Tiêu đề là bắt buộc'),
   body('content').notEmpty().withMessage('Nội dung là bắt buộc'),
- body('type')
- .notEmpty().withMessage('Loại thông báo là bắt buộc')
- .isIn(['INFO', 'PROMOTION', 'WARNING', 'DELAY']).withMessage('Loại thông báo không hợp lệ'),
+  body('type')
+    .notEmpty()
+    .withMessage('Loại thông báo là bắt buộc')
+    .isIn(['INFO', 'PROMOTION', 'WARNING', 'DELAY', 'MAINTENANCE'])
+    .withMessage('Loại thông báo không hợp lệ'),
+  body('status')
+    .notEmpty()
+    .withMessage('Trạng thái là bắt buộc')
+    .isIn(['ACTIVE', 'INACTIVE', 'ARCHIVED'])
+    .withMessage('Trạng thái không hợp lệ'),
+  body('start_date')
+    .notEmpty()
+    .withMessage('Ngày bắt đầu là bắt buộc')
+    .isISO8601()
+    .toDate()
+    .withMessage('Ngày bắt đầu không hợp lệ'),
+  body('end_date')
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage('Ngày kết thúc không hợp lệ')
+    .custom((value, { req }) => {
+      if (value && req.body.start_date && new Date(value) <= new Date(req.body.start_date)) {
+        throw new Error('Ngày kết thúc phải sau ngày bắt đầu');
+      }
+      return true;
+    }),
 
 ];
 
@@ -18,9 +42,31 @@ exports.validateUpdateAnnouncement = [
  body('content')
  .optional()
  .notEmpty().withMessage('Nội dung không được rỗng nếu có'),
- body('type')
+  body('type')
     .optional()
-    .isIn(['INFO', 'PROMOTION', 'WARNING', 'DELAY']).withMessage('Loại thông báo không hợp lệ'),
+    .isIn(['INFO', 'PROMOTION', 'WARNING', 'DELAY', 'MAINTENANCE'])
+    .withMessage('Loại thông báo không hợp lệ'),
+  body('status')
+    .optional()
+    .isIn(['ACTIVE', 'INACTIVE', 'ARCHIVED'])
+    .withMessage('Trạng thái không hợp lệ'),
+  body('start_date')
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage('Ngày bắt đầu không hợp lệ'),
+  body('end_date')
+    .optional()
+    .isISO8601()
+    .toDate()
+    .withMessage('Ngày kết thúc không hợp lệ')
+    .custom((value, { req }) => {
+      const start = req.body.start_date;
+      if (value && start && new Date(value) <= new Date(start)) {
+        throw new Error('Ngày kết thúc phải sau ngày bắt đầu');
+      }
+      return true;
+    }),
 ];
 exports.validateDeleteAnnouncement = [
   param('id').isUUID().withMessage('ID thông báo không hợp lệ')


### PR DESCRIPTION
## Summary
- support MAINTENANCE announcement type
- validate status, start_date and end_date for announcements

## Testing
- `npm test --prefix backend` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840c78de9988330b6d5d1ccfcd06534