### PR TITLE
Use shared validation handler

### DIFF
--- a/backend/middlewares/validateAirline.js
+++ b/backend/middlewares/validateAirline.js
@@ -1,4 +1,4 @@
-const { body, param, validationResult } = require('express-validator');
+const { body, param } = require('express-validator');
 const { handleValidationErrors } = require('../middlewares/validateUtils');
 
 exports.validateCreateAirline = [
@@ -26,14 +26,3 @@ exports.validateGetAirlineById = [
 exports.validateDeleteAirline = [
   param('id').isUUID().withMessage('ID hãng hàng không không hợp lệ')
 ];
-
-// Middleware xử lý lỗi validation
-exports.handleValidationErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    console.error('❌ Validation Errors:', errors.array()); // Sử dụng console.error cho lỗi
-    // Chỉ trả về thông báo lỗi đầu tiên để đơn giản
-    return res.status(400).json({ success: false, error: errors.array()[0].msg });
-  }
-  next();
-};

--- a/backend/middlewares/validateAuth.js
+++ b/backend/middlewares/validateAuth.js
@@ -12,13 +12,3 @@ exports.validateRegister = [
     .notEmpty().withMessage('Password is required')
     .isLength({ min: 6 }).withMessage('Password must be at least 6 characters long'),
 ];
-
-// Middleware xử lý lỗi validation
-exports.handleValidationErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    console.log('❌ Validation Errors:', errors.array()); // Thêm log
-    return res.status(400).json({ success: false, error: errors.array()[0].msg });
-  }
-  next();
-};

--- a/backend/middlewares/validateCountry.js
+++ b/backend/middlewares/validateCountry.js
@@ -1,4 +1,4 @@
-const { body, param, validationResult } = require('express-validator');
+const { body, param } = require('express-validator');
 const { handleValidationErrors } = require('../middlewares/validateUtils');
 
 exports.validateCreateCountry = [
@@ -33,15 +33,6 @@ exports.validateDeleteCountry = [
   param('id').isUUID().withMessage('Country ID is invalid'),
 ];
 
-// Middleware xử lý lỗi validation
-exports.handleValidationErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    console.log('❌ Validation Errors:', errors.array()); // Thêm log
-    return res.status(400).json({ success: false, error: errors.array()[0].msg });
-  }
-  next();
-};
 
 exports.validateGetAllCountries = [
   // Add validation rules for query parameters here if needed

--- a/backend/middlewares/validatePassenger.js
+++ b/backend/middlewares/validatePassenger.js
@@ -1,4 +1,4 @@
-const { body, param, validationResult } = require('express-validator');
+const { body, param } = require('express-validator');
 const { handleValidationErrors } = require('../middlewares/validateUtils');
 
 exports.validateCreatePassenger = [
@@ -21,15 +21,6 @@ exports.validateRegister = [
   // Removed validations for first_name, last_name, username as they are handled during passenger creation
 ];
 
-// Middleware xử lý lỗi validation
-exports.handleValidationErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    console.log('❌ Validation Errors:', errors.array()); // Thêm log
-    return res.status(400).json({ success: false, error: errors.array()[0].msg });
-  }
-  next();
-};
 
 exports.validateUpdatePassenger = [
   param('id').isUUID().withMessage('ID hành khách không hợp lệ'),
@@ -51,12 +42,3 @@ exports.validateGetPassengerById = [
 exports.validateDeletePassenger = [
   param('id').isUUID().withMessage('ID hành khách không hợp lệ')
 ];
-// Middleware xử lý lỗi validation
-exports.handleValidationErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    console.log('❌ Validation Errors:', errors.array()); // Thêm log
-    return res.status(400).json({ success: false, error: errors.array()[0].msg });
-  }
-  next();
-};

--- a/backend/middlewares/validateServiceOffering.js
+++ b/backend/middlewares/validateServiceOffering.js
@@ -1,4 +1,4 @@
-const { body, param, validationResult } = require('express-validator');
+const { body, param } = require('express-validator');
 const { handleValidationErrors } = require('../middlewares/validateUtils');
 
 exports.validateCreateServiceOffering = [
@@ -65,13 +65,3 @@ exports.validateDeleteServiceOffering = [
     .isUUID().withMessage('Invalid service_id UUID format in param'),
 ];
 
-
-// Middleware xử lý lỗi validation (assuming it will be moved later)
-exports.handleValidationErrors = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    console.error('❌ Validation Errors:', errors.array()); // Use error for errors
-    return res.status(400).json({ success: false, error: errors.array().map(err => err.msg).join(', ') }); // Return all error messages
-  }
-  next();
-};


### PR DESCRIPTION
## Summary
- remove duplicated `handleValidationErrors` implementations
- rely on shared handler from `validateUtils`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840c79278008330aafe3e83c4a9ef5f