### PR TITLE
Add seat numbers to seats

### DIFF
--- a/backend/models/SeatDetail.js
+++ b/backend/models/SeatDetail.js
@@ -1,10 +1,12 @@
 class SeatDetail {
   constructor({
     id,
+    seat_number,
     travel_class_id,
     flight_id
   }) {
     this.id = id;
+    this.seat_number = seat_number;
     this.travel_class_id = travel_class_id;
     this.flight_id = flight_id;
   }

--- a/backend/services/StatisticService.js
+++ b/backend/services/StatisticService.js
@@ -46,6 +46,7 @@ class StatisticService {
         p.first_name,
         p.last_name,
         sd.id AS seat_detail_id, -- Include seat detail ID
+        sd.seat_number,
         tc.name AS travel_class_name, -- Assuming travel_classes table has name
         ps.amount AS paid_amount, -- Amount from payment_statuses
         ps.status AS payment_status, -- Status from payment_statuses ('Y'/'N')


### PR DESCRIPTION
## Summary
- add seat_number to SeatDetail model
- generate seat numbers when creating seats in flight service
- include seat_number when fetching passengers or recent reservations

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684253e16d5c8330a62b27ac663af10b