### PR TITLE
Fix axios headers for caching

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -773,10 +773,12 @@ export const getRevenueByTravelClass = async () => {
 export const getCities = async () => {
   try {
     const response = await axios.get(`${API_URL}/cities`, {
-      headers: getAuthHeaders(),
-      'Cache-Control': 'no-cache',
-      Pragma: 'no-cache',
-      Expires: '0',
+      headers: {
+        ...getAuthHeaders(),
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
     });
     return response.data;
   } catch (error) {
@@ -1002,10 +1004,12 @@ export const deleteAirline = async (id) => {
 export const getAirports = async () => {
   try {
     const response = await axios.get(`${API_URL}/airports`, {
-      headers: getAuthHeaders(),
-      'Cache-Control': 'no-cache',
-      Pragma: 'no-cache',
-      Expires: '0',
+      headers: {
+        ...getAuthHeaders(),
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        Expires: '0',
+      },
     });
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- place no-cache headers inside the `headers` object for axios calls

## Testing
- `npm test` in `backend` *(fails: no test specified)*
- `npm test` in `frontend` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d2436cfc83308fd0910f13cfad36