### PR TITLE
Fix axios response handling

### DIFF
--- a/frontend/src/pages/Admin.js
+++ b/frontend/src/pages/Admin.js
@@ -22,8 +22,8 @@ function Admin() {
             getTicketStats()
         ])
             .then(([flightsRes, statsRes]) => {
-                setFlights(flightsRes.data);
-                setStats(statsRes.data);
+                setFlights(flightsRes.data.data);
+                setStats(statsRes.data.data);
             })
             .catch(err => setError('Không thể tải dữ liệu: ' + err.message))
             .finally(() => setLoading(false));

--- a/frontend/src/pages/Booking.js
+++ b/frontend/src/pages/Booking.js
@@ -170,7 +170,7 @@ function Booking() {
         };
         console.log('Sending customer data:', customerData); // Debug
         const res = await axios.post(`${API_URL}/api/customer/register`, customerData);
-        setCustomer(res.data.user);
+        setCustomer(res.data.data.user);
       } else {
         setCustomer({
           ...customer,

--- a/frontend/src/pages/Flights.js
+++ b/frontend/src/pages/Flights.js
@@ -94,7 +94,7 @@ function Flights() {
       console.log('Search data:', searchData);
       const res = await searchFlights(searchData);
       console.log('Search response:', res.data);
-      const flightsData = Array.isArray(res.data) ? res.data : [];
+      const flightsData = Array.isArray(res.data.data) ? res.data.data : [];
       const sortedFlights = flightsData.sort((a, b) => new Date(a.departure_time) - new Date(b.departure_time));
       setFlights(sortedFlights);
       if (sortedFlights.length === 0) {

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -18,33 +18,35 @@ function Login() {
       let res;
       if (role === 'customer') {
         res = await loginCustomer(data);
-        if (!res.data || !res.data.user || !res.data.user.id) {
+        const userData = res.data.data;
+        if (!userData || !userData.user || !userData.user.id) {
           throw new Error('Dữ liệu người dùng không hợp lệ');
         }
-        login(res.data);
-        localStorage.setItem('token', res.data.token);
-        localStorage.setItem('userId', res.data.user.id);
-        localStorage.setItem('email', res.data.user.email);
+        login(userData);
+        localStorage.setItem('token', userData.token);
+        localStorage.setItem('userId', userData.user.id);
+        localStorage.setItem('email', userData.user.email);
         localStorage.setItem('role', 'customer');
-        localStorage.setItem('username', res.data.user.username || '');
-        localStorage.setItem('first_name', res.data.user.first_name);
-        localStorage.setItem('last_name', res.data.user.last_name || '');
+        localStorage.setItem('username', userData.user.username || '');
+        localStorage.setItem('first_name', userData.user.first_name);
+        localStorage.setItem('last_name', userData.user.last_name || '');
         navigate('/');
       } else {
         res = await loginEmployee(data);
         console.log('📊 Phản hồi từ API đăng nhập nhân viên:', res.data);
-        if (!res.data || !res.data.employee || !res.data.employee.id) {
+        const employeeData = res.data.data;
+        if (!employeeData || !employeeData.employee || !employeeData.employee.id) {
           throw new Error('Dữ liệu nhân viên không hợp lệ');
         }
         // Chuẩn hóa vai trò trước khi lưu
-        const employeeRole = res.data.employee.role.toLowerCase();
-        login(res.data);
-        localStorage.setItem('token', res.data.token);
-        localStorage.setItem('userId', res.data.employee.id);
-        localStorage.setItem('email', res.data.employee.email);
+        const employeeRole = employeeData.employee.role.toLowerCase();
+        login(employeeData);
+        localStorage.setItem('token', employeeData.token);
+        localStorage.setItem('userId', employeeData.employee.id);
+        localStorage.setItem('email', employeeData.employee.email);
         localStorage.setItem('role', employeeRole);
-        localStorage.setItem('first_name', res.data.employee.first_name || '');
-        localStorage.setItem('last_name', res.data.employee.last_name || '');
+        localStorage.setItem('first_name', employeeData.employee.first_name || '');
+        localStorage.setItem('last_name', employeeData.employee.last_name || '');
         if (employeeRole === 'admin') {
           navigate('/admin');
         } else {

--- a/frontend/src/pages/Promotions.js
+++ b/frontend/src/pages/Promotions.js
@@ -12,7 +12,7 @@ function Promotions() {
     useEffect(() => {
         setLoading(true);
         getAnnouncements()
-            .then(res => setPromotions(res.data || []))
+            .then(res => setPromotions(res.data.data || []))
             .catch(err => {
                 setError('Không thể tải danh sách thông báo: ' + err.message);
                 // Sử dụng dữ liệu tĩnh làm dự phòng

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -13,12 +13,13 @@ function Register() {
   const onSubmit = async (data) => {
     try {
       const res = await registerCustomer(data);
-      localStorage.setItem('token', res.data.token);
-      localStorage.setItem('userId', res.data.user.id);
-      localStorage.setItem('email', res.data.user.email);
-      localStorage.setItem('username', res.data.user.username || '');
-      localStorage.setItem('first_name', res.data.user.first_name);
-      localStorage.setItem('last_name', res.data.user.last_name || '');
+      const userData = res.data.data;
+      localStorage.setItem('token', userData.token);
+      localStorage.setItem('userId', userData.user.id);
+      localStorage.setItem('email', userData.user.email);
+      localStorage.setItem('username', userData.user.username || '');
+      localStorage.setItem('first_name', userData.user.first_name);
+      localStorage.setItem('last_name', userData.user.last_name || '');
       alert('Đăng ký thành công!');
       navigate('/login');
     } catch (err) {

--- a/frontend/src/pages/admin/Announcements.js
+++ b/frontend/src/pages/admin/Announcements.js
@@ -11,7 +11,7 @@ function AdminAnnouncements() {
     useEffect(() => {
         setLoading(true);
         getAnnouncements()
-            .then(res => setAnnouncements(res.data || []))
+            .then(res => setAnnouncements(res.data.data || []))
             .catch(err => setError('Không thể tải thông báo: ' + err.message))
             .finally(() => setLoading(false));
     }, []);
@@ -20,7 +20,7 @@ function AdminAnnouncements() {
         e.preventDefault();
         try {
             const newAnnouncement = await createAnnouncement(form);
-            setAnnouncements([...announcements, newAnnouncement.data]);
+            setAnnouncements([...announcements, newAnnouncement.data.data]);
             setForm({ title: '', content: '', expiryDate: '', image: '' });
             alert('Đăng thông báo thành công!');
         } catch (err) {

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -46,12 +46,12 @@ export const registerCustomer = async (data) => {
       headers: { 'Content-Type': 'application/json' },
     });
     // Lưu token và role vào localStorage
-    if (response.data.token) {
-      localStorage.setItem('token', response.data.token);
-      localStorage.setItem('user_id', response.data.user?.id);
-      localStorage.setItem('role', response.data.user?.role);
+    if (response.data?.data?.token) {
+      localStorage.setItem('token', response.data.data.token);
+      localStorage.setItem('user_id', response.data.data.user?.id);
+      localStorage.setItem('role', response.data.data.user?.role);
     }
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -68,12 +68,12 @@ export const loginCustomer = async (data) => {
     const payload = { email: data.email, password: data.password };
     const response = await axios.post(`${API_URL}/auth/login`, payload, { headers: getAuthHeaders() });
     // Lưu token và role vào localStorage
-    if (response.data.token) {
-      localStorage.setItem('token', response.data.token);
-      localStorage.setItem('user_id', response.data.user?.id);
-      localStorage.setItem('role', response.data.user?.role);
+    if (response.data?.data?.token) {
+      localStorage.setItem('token', response.data.data.token);
+      localStorage.setItem('user_id', response.data.data.user?.id);
+      localStorage.setItem('role', response.data.data.user?.role);
     }
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -88,7 +88,7 @@ export const loginCustomer = async (data) => {
 export const getFlights = async () => {
   try {
     const response = await axios.get(`${API_URL}/flights`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -103,7 +103,7 @@ export const getFlights = async () => {
 export const searchFlights = async (data) => {
   try {
     const response = await axios.post(`${API_URL}/flights/search`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -118,7 +118,7 @@ export const searchFlights = async (data) => {
 export const getFlight = async (flightId) => {
   try {
     const response = await axios.get(`${API_URL}/flights/${flightId}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -135,7 +135,7 @@ export const delayFlight = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/flights/${id}/delay`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -151,7 +151,7 @@ export const createFlight = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/flights`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -167,7 +167,7 @@ export const cancelFlight = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/flights/${id}/cancel`, {}, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -183,7 +183,7 @@ export const deleteFlight = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/flights/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -199,7 +199,7 @@ export const deleteFlight = async (id) => {
 export const bookTicket = async (data) => {
   try {
     const response = await axios.post(`${API_URL}/reservations`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -214,7 +214,7 @@ export const bookTicket = async (data) => {
 export const cancelTicket = async (id) => {
   try {
     const response = await axios.put(`${API_URL}/reservations/${id}/cancel`, {}, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -232,7 +232,7 @@ export const getTickets = async () => {
       throw new Error('Không tìm thấy passengerId trong localStorage');
     }
     const response = await axios.get(`${API_URL}/passengers/${passengerId}/reservations`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -247,7 +247,7 @@ export const getTickets = async () => {
 export const getReservation = async (id) => {
   try {
     const response = await axios.get(`${API_URL}/reservations/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -264,7 +264,7 @@ export const createPassenger = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/passengers`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -280,7 +280,7 @@ export const getPassenger = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/passengers/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -297,7 +297,7 @@ export const updatePassenger = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/passengers/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -313,7 +313,7 @@ export const deletePassenger = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/passengers/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -331,10 +331,10 @@ export const linkPassengerToUser = async (passengerId, userId) => {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/passengers/${passengerId}/link-user/${userId}`, {}, { headers: getAuthHeaders() });
     // Lưu passengerId vào localStorage nếu liên kết thành công
-    if (response.data.passengerId) {
-      localStorage.setItem('passengerId', response.data.passengerId);
+    if (response.data?.data?.passengerId) {
+      localStorage.setItem('passengerId', response.data.data.passengerId);
     }
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -349,7 +349,7 @@ export const linkPassengerToUser = async (passengerId, userId) => {
 export const getAnnouncements = async () => {
   try {
     const response = await axios.get(`${API_URL}/announcements`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -365,7 +365,7 @@ export const createAnnouncement = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/announcements`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -382,7 +382,7 @@ export const updateAnnouncement = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/announcements/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -398,7 +398,7 @@ export const deleteAnnouncement = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/announcements/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -413,7 +413,7 @@ export const deleteAnnouncement = async (id) => {
 export const getAircrafts = async () => {
   try {
     const response = await axios.get(`${API_URL}/aircrafts`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -428,7 +428,7 @@ export const getAircrafts = async () => {
 export const getAircraftById = async (id) => {
   try {
     const response = await axios.get(`${API_URL}/aircrafts/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -444,7 +444,7 @@ export const createAircraft = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/aircrafts`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -461,7 +461,7 @@ export const updateAircraft = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/aircrafts/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -477,7 +477,7 @@ export const deleteAircraft = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/aircrafts/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -492,7 +492,7 @@ export const deleteAircraft = async (id) => {
 export const getTicketClasses = async () => {
   try {
     const response = await axios.get(`${API_URL}/ticket-classes`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -508,7 +508,7 @@ export const createTicketClass = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/ticket-classes`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -525,7 +525,7 @@ export const updateTicketClass = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/ticket-classes/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -541,7 +541,7 @@ export const deleteTicketClass = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/ticket-classes/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -555,7 +555,7 @@ export const deleteTicketClass = async (id) => {
 export const getPerksForTicketClass = async () => {
   try {
     const response = await axios.get(`${API_URL}/service-offerings`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -570,7 +570,7 @@ export const getPerksForTicketClass = async () => {
 export const getServiceOfferings = async () => {
   try {
     const response = await axios.get(`${API_URL}/service-offerings`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -586,7 +586,7 @@ export const getServiceOfferings = async () => {
 export const getServiceOfferingById = async (travelClassId, serviceId) => {
   try {
     const response = await axios.get(`${API_URL}/service-offerings/${travelClassId}/${serviceId}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -602,7 +602,7 @@ export const createServiceOffering = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/service-offerings`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -620,7 +620,7 @@ export const updateServiceOffering = async (travelClassId, serviceId, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/service-offerings/${travelClassId}/${serviceId}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -637,7 +637,7 @@ export const deleteServiceOffering = async (travelClassId, serviceId) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/service-offerings/${travelClassId}/${serviceId}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -653,7 +653,7 @@ export const getAdminStats = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/stats`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -668,7 +668,7 @@ export const getRecentBookings = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/recent-bookings`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -683,7 +683,7 @@ export const getUpcomingFlights = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/upcoming-flights`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -698,7 +698,7 @@ export const getBookingTrends = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/booking-trends`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -713,7 +713,7 @@ export const getRevenueByTime = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/stats/revenue-by-time`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -728,7 +728,7 @@ export const getRevenueByRoute = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/stats/revenue-by-route`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -743,7 +743,7 @@ export const getRevenueByAirline = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/stats/revenue-by-airline`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -758,7 +758,7 @@ export const getRevenueByTravelClass = async () => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/stats/revenue-by-travel-class`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -778,7 +778,7 @@ export const getCities = async () => {
       Pragma: 'no-cache',
       Expires: '0',
     });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -794,7 +794,7 @@ export const getCityById = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/cities/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -810,7 +810,7 @@ export const createCity = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/cities`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -827,7 +827,7 @@ export const updateCity = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/cities/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -843,7 +843,7 @@ export const deleteCity = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/cities/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -858,7 +858,7 @@ export const deleteCity = async (id) => {
 export const getCountries = async () => {
   try {
     const response = await axios.get(`${API_URL}/countries`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -874,7 +874,7 @@ export const getCountryById = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.get(`${API_URL}/countries/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -890,7 +890,7 @@ export const createCountry = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/countries`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -907,7 +907,7 @@ export const updateCountry = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/countries/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -923,7 +923,7 @@ export const deleteCountry = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/countries/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -938,7 +938,7 @@ export const deleteCountry = async (id) => {
 export const getAirlines = async () => {
   try {
     const response = await axios.get(`${API_URL}/airlines`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -954,7 +954,7 @@ export const createAirline = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/airlines`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -971,7 +971,7 @@ export const updateAirline = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/airlines/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -987,7 +987,7 @@ export const deleteAirline = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/airlines/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -1007,7 +1007,7 @@ export const getAirports = async () => {
       Pragma: 'no-cache',
       Expires: '0',
     });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -1022,7 +1022,7 @@ export const getAirports = async () => {
 export const getAirportById = async (id) => {
   try {
     const response = await axios.get(`${API_URL}/airports/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -1038,7 +1038,7 @@ export const createAirport = async (data) => {
   try {
     checkAdminRole();
     const response = await axios.post(`${API_URL}/airports`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -1055,7 +1055,7 @@ export const updateAirport = async (id, data) => {
   try {
     checkAdminRole();
     const response = await axios.put(`${API_URL}/airports/${id}`, data, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }
@@ -1071,7 +1071,7 @@ export const deleteAirport = async (id) => {
   try {
     checkAdminRole();
     const response = await axios.delete(`${API_URL}/airports/${id}`, { headers: getAuthHeaders() });
-    return response.data;
+    return response;
   } catch (error) {
     handleApiError(error);
   }


### PR DESCRIPTION
## Summary
- update auth service to parse token/user from `response.data.data`
- return full axios responses from API helpers
- adjust pages to read data from `res.data`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842d243420c833086c92649e1d2eeb8