### PR TITLE
Update booking page to use API helpers

### DIFF
--- a/frontend/src/pages/SeatSelection.js
+++ b/frontend/src/pages/SeatSelection.js
@@ -81,13 +81,14 @@ const SeatSelection = () => {
       return;
     }
     setLoading(true);
-    // Chuyển về Booking.js với ghế đã chọn
+    const [, row, seatId] = selectedSeat.split('-');
+    const seatNumber = `${row}${seatId}`;
     navigate('/booking', {
       state: {
         flight,
         ticketType,
         customer,
-        formData: { ...formData, seat_number: selectedSeat }
+        formData: { ...formData, seat_id: seatId, seat_number: seatNumber }
       }
     });
   };

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -26,6 +26,24 @@ const handleApiError = (error) => {
   throw new Error(`Lỗi API: ${message}`);
 };
 
+/**
+ * Kiểm tra hành khách theo email
+ * @param {string} email - Địa chỉ email cần kiểm tra
+ * @returns {Promise} Promise trả về danh sách hành khách tìm được
+ * @throws {Error} Nếu yêu cầu thất bại
+ */
+export const checkPassengerEmail = async (email) => {
+  try {
+    const response = await axios.get(`${API_URL}/passengers`, {
+      params: { email },
+      headers: { 'Content-Type': 'application/json', ...getAuthHeaders() },
+    });
+    return response;
+  } catch (error) {
+    handleApiError(error);
+  }
+};
+
 // API Xác thực
 /**
  * Đăng ký hành khách mới


### PR DESCRIPTION
## Summary
- add `checkPassengerEmail` helper for looking up passengers
- refactor booking page to use service helpers instead of raw axios
- carry seat information as `seat_id` from seat selection

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842dba7a1b88330a31563c87b4a2aa5